### PR TITLE
Update install instructions for non-root users

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,9 +7,11 @@
 Simplified location changer based on http://tech.inhelsinki.nl/locationchanger/
 
 ##Installation
-Note: location name should be the same as the name of SSID
+Notes: the location name should be the same as the name of SSID and the plist must be owned by root to avoid the `Dubious ownership on file` security issue (see this [SO post][so]).
 
     cp locationchanger /usr/local/bin
     cp LocationChanger.plist ~/Library/LaunchAgents/
-    launchctl load ~/Library/LaunchAgents/LocationChanger.plist
+    sudo chown root ~/Library/LaunchAgents/LocationChanger.plist
+    sudo launchctl load ~/Library/LaunchAgents/LocationChanger.plist
 
+[so]: https://apple.stackexchange.com/questions/3250/why-am-i-getting-a-dubious-ownership-of-file-error-when-launch-agent-runs-my


### PR DESCRIPTION
came across a `launchctl: Dubious ownership on file` error on Mavericks — not sure if this is persistent across older versions of OSX but I figured that this would be a better way of initializing the script, regardless.
