### PR TITLE
Don't change network location if it's already set properly

### DIFF
--- a/locationchanger
+++ b/locationchanger
@@ -55,8 +55,17 @@ if [ -z "$LOCATION" ]; then
 	REASON="Automatic Fallback"
 fi
 
+# Don't change if we're already there
+current_location=$(networksetup -getcurrentlocation)
+if [ "$current_location" = "$LOCATION" ]; then
+    exit
+fi
+
 # change network location
-scselect "$LOCATION"
+if ! networksetup -switchtolocation "$LOCATION"; then
+    osascript -e 'display notification "Failed to Update Network Location" with title "Network Location Failure"'
+    exit 1
+fi
 
 case $LOCATION in
 	$Location_Automatic )


### PR DESCRIPTION
If the current network location is correct, then don't change the
network location or display a notification.

To effect this change, switch from `scselect` to `networksetup` for
setting the network location (and for finding out the current network
location).

Also, check to make sure `networksetup` succeeds and display an error
notification if it doesn't.