### PR TITLE
launchctl: avoid deprecated commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+locationchanger.callout.sh

--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ See log in action:
 ```bash
 tail -f /usr/local/var/log/locationchanger.log
 ```
+
+## Run arbitrary script when location changes
+
+By convention, placing an executable script in this directory with name:
+
+`locationchanger.callout.sh`
+
+and then running the installer, will cause the locationchanger service to run that script each time location changes.

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,40 @@
 #!/bin/bash
 
+set -eu
+
 chmod +x locationchanger
 sudo mkdir -p /usr/local/bin
 sudo cp -a locationchanger /usr/local/bin
 cp LocationChanger.plist ~/Library/LaunchAgents/
-launchctl unload ~/Library/LaunchAgents/LocationChanger.plist
-launchctl load ~/Library/LaunchAgents/LocationChanger.plist
+
+# remove older service if found
+launchctl list | grep --quiet "locationchanger" && launchctl unload ~/Library/LaunchAgents/LocationChanger.plist
+
+# conditionalize on macos version
+major_version=$(sw_vers -productVersion | awk -F. '{ print $1; }')
+
+if [[ $major_version -ge 11 ]]; then
+    # "big sur" or later
+
+    # service name includes user ID
+    loggedInUser=$( ls -l /dev/console | awk '{print $3}' )
+    userID=$( id -u $loggedInUser )
+    service_name="gui/$userID/locationchanger"
+
+    # fyi, removal of new service can be done via:
+    # sudo launchctl bootout $service_name
+
+    # bootstrap (install) as necessary
+    sudo launchctl print $service_name >> /dev/null 2>&1 || sudo launchctl bootstrap gui/$userID ~/Library/LaunchAgents/LocationChanger.plist
+
+    sudo launchctl enable $service_name
+
+    # kickstart -k will RESTART process, using any updated code
+    sudo launchctl kickstart -k $service_name
+    echo "The service \"$service_name\" has been installed and started"
+else
+    # for older macos
+
+    launchctl load ~/Library/LaunchAgents/LocationChanger.plist
+    echo "The service \"locationchanger\" has been installed and started"
+fi

--- a/install.sh
+++ b/install.sh
@@ -38,3 +38,11 @@ else
     launchctl load ~/Library/LaunchAgents/LocationChanger.plist
     echo "The service \"locationchanger\" has been installed and started"
 fi
+
+# install any external callout that is present
+EXTERNAL_CALLOUT_FILE="./locationchanger.callout.sh"
+if [[ -f "$EXTERNAL_CALLOUT_FILE" ]]; then
+    chmod +x $EXTERNAL_CALLOUT_FILE
+    sudo cp -a $EXTERNAL_CALLOUT_FILE /usr/local/bin
+    echo "An external callout ($EXTERNAL_CALLOUT_FILE) was installed also"
+fi

--- a/locationchanger
+++ b/locationchanger
@@ -11,12 +11,13 @@
 # redirect all IO to a logfile
 mkdir -p /usr/local/var/log
 exec &>/usr/local/var/log/locationchanger.log
-# redirect all IO to /dev/null (comment this in if you don#t want to write to logfile)
+
+# to avoid any output, any logfile, uncomment the following:
 #exec 1>/dev/null 2>/dev/null
 
-# get a little breather before we get data for things to settle down
+# this service is called immediately after network activity.
+# sleep a bit to make sure that info is finished writing to disk about those network changes
 sleep 2
-
 
 # get SSID
 SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport -I | awk -F ' SSID: ' '/ SSID:/ {print $2}'`
@@ -65,6 +66,18 @@ fi
 if ! networksetup -switchtolocation "$LOCATION"; then
     osascript -e 'display notification "Failed to Update Network Location" with title "Network Location Failure"'
     exit 1
+fi
+
+# if present, callout to an external script
+# use this script's dir and convention to determine if there is an external script to be run
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+EXTERNAL_CALLOUT="$SCRIPT_DIR/locationchanger.callout.sh"
+if [[ -x "$EXTERNAL_CALLOUT" ]]; then
+		output=$($EXTERNAL_CALLOUT)
+		exit_code=$?
+		echo "External callout \"$EXTERNAL_CALLOUT\" returned exit code: $exit_code and output:"
+		echo "$output"
+		echo ""
 fi
 
 case $LOCATION in


### PR DESCRIPTION
fix rimar/wifi-location-changer#31 for launchctl: avoid deprecated commands

* conditionalize on Big Sur (11+) macOS version for newer launchctl usage
* conditionalize to unload only as necessary