### PR TITLE
Fixes #33, add feature for configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 locationchanger.callout.sh
+locationchanger.conf

--- a/README.md
+++ b/README.md
@@ -1,65 +1,32 @@
 # Mac OSX Wi-Fi Location Changer
 
-* Automatically changes the Mac OSX network location when Wi-Fi connection SSID changes
+* Automatically changes the Mac OSX network location when a configured Wi-Fi (SSID) becomes connected
 * Allows having different IP settings depending on the Wi-Fi SSID
-
-**Note:** Mountain Lion compatible
+* Offers hook to run external script when location changes
 
 ## Configuration
-There are two areas that need to be modified in the locationchanger script, Locations and SSIDs. Both of which are case sensitive. 
-
-### Locations
-Edit locationchanger and change/add locations to be set:
-
-**Note:** Ensure you use the exact names as they appear under "Location" in OSX's System Preferences -> Network
+Create a configuration file using the sample:
 
 ```bash
-# LOCATIONS 
-Location_Automatic="Automatic"
-Location_Work="Company Intranet"
+cp ./locationchanger.config.sample ./locationchanger.conf
 ```
 
-### SSIDs
-Edit locationchanger and add/edit SSIDs to be detected:
+Add to this new file (`./locationchanger.conf`) a single line for each pair of location and SSID that you want this service to recognize and set when the SSID connects. That is, for each location, add one line with both a location name and a Wi-Fi SSID, separated by a space, taking care to use exact capitalization, and using quotations as necessary.
 
-```bash
-# SSIDS
-SSID_TelekomPublic=Telekom
-SSID_Home=HomeSSID
-SSID_Work=WorkSSID
-```
+For example, if your location is "home", and the Wi-Fi SSID to trigger that location is "myWifiName", then a line in the configuration file would look like:
 
-Edit/Add SSID -> LOCATION mapping to list:
+`home myWifiName`
 
-```bash
-# SSID -> LOCATION mapping
-case $SSID in
-	$SSID_TelekomPublic ) LOCATION="$Location_Automatic";;
-	$SSID_Home          ) LOCATION="$Location_Automatic";;
-	$SSID_Work  ) LOCATION="$Location_Work";;
-	# ... add more here
-```
+If your SSID is instead a name like Wu Tang LAN, with spaces, then use quotes around the SSID like:
+
+`home "Wu Tang LAN"`
+
+**Note:** Ensure you use the exact location names as they appear under "Location" in OSX's System Preferences -> Network, and for SSIDs in your Wi-Fi menu. Capitalization must match! Spaces must match within a quoted name!
+
+Add as many location + SSID lines as you like to the configuration file.
 
 ### MacOS Notifications
-The script triggers a MacOS Notification, if you don't want this just delete the three lines that start with `osascript` around line 57. If you add or delete Locations, the case needs to be updated.
-
-```bash
-case $LOCATION in
-        $Location_Automatic )
-                # do stuff here you would do in Location_Automatic
-                osascript -e 'display notification "Network Location Changed to Automatic" with title "Network Location Changed"'
-        ;;
-
-        $Location_Home )
-                osascript -e 'display notification "Network Location Changed to Home" with title "Network Location Changed"'
-        ;;
-
-        $Location_Work )
-                osascript -e 'display notification "Network Location Changed to Work" with title "Network Location Changed"'
-        ;;
-				# ... add more here
-esac
-```
+The script triggers a MacOS Notification upon changing location. If you don't want this just delete the lines that start with `osascript`.
 
 ## Installation
 
@@ -75,6 +42,7 @@ Execute:
 Copy these files:
 ```bash
 cp locationchanger /usr/local/bin
+cp locationchanger.conf /usr/local/bin
 cp LocationChanger.plist ~/Library/LaunchAgents/
 ```
 Should you place the locationchanger script to another location, make sure you edit the path in LocationChanger.plist too.
@@ -105,3 +73,11 @@ By convention, placing an executable script in this directory with name:
 `locationchanger.callout.sh`
 
 and then running the installer, will cause the locationchanger service to run that script each time location changes.
+
+### Testing
+
+For ease in testing, configure two locations within the current environment, e.g., "home" and "guest", each associated with a different SSID, such as the main SSID and guest SSID on your router. Then using the Wi-Fi menu, toggle between those SSIDs. You can see any success or error messages that are written to the log with a command like:
+
+```
+tail /usr/local/var/log/locationchanger.log
+```

--- a/install.sh
+++ b/install.sh
@@ -46,3 +46,9 @@ if [[ -f "$EXTERNAL_CALLOUT_FILE" ]]; then
     sudo cp -a $EXTERNAL_CALLOUT_FILE /usr/local/bin
     echo "An external callout ($EXTERNAL_CALLOUT_FILE) was installed also"
 fi
+
+# install mapping file
+MAPPING_FILE="./locationchanger.conf"
+if [[ -f "$MAPPING_FILE" ]]; then
+    sudo cp -a $MAPPING_FILE /usr/local/bin
+fi

--- a/locationchanger
+++ b/locationchanger
@@ -19,6 +19,9 @@ exec &>/usr/local/var/log/locationchanger.log
 # sleep a bit to make sure that info is finished writing to disk about those network changes
 sleep 2
 
+# determine location of this script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # get SSID
 SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport -I | awk -F ' SSID: ' '/ SSID:/ {print $2}'`
 echo `date` "New SSID found: $SSID"
@@ -47,8 +50,29 @@ case $SSID in
 	$SSID_Work  ) LOCATION="$Location_Work";;
 	# ... add more here
 esac
-	REASON="SSID changed to $SSID"
+REASON="SSID changed to $SSID"
 
+# process mapping from text file
+MAP_FILE=$SCRIPT_DIR/locationchanger.conf
+if [ -f "$MAP_FILE" ]; then
+  # echo "Checking mappings from file \"$MAP_FILE\""
+  while IFS=' ' read -r loc wifi
+  do
+		if [[ "${loc}" == "#"*   ]]; then
+			true # ignore comments
+		elif [ -z "${loc}" ]; then
+      true # ignore empty lines
+		else
+			wifi=$(echo $wifi | tr -d '"' ) # remove quotes
+			# echo "location, wifi: \"$loc\", \"$wifi\" "
+			if [[ "$wifi" == "$SSID" ]]; then
+					LOCATION="$loc"
+					REASON="SSID changed to $SSID using mapping file"
+					break
+			fi
+		fi
+  done < "$MAP_FILE"
+fi
 
 # still didn't get a location -> use Location_Automatic
 if [ -z "$LOCATION" ]; then
@@ -62,38 +86,24 @@ if [ "$current_location" = "$LOCATION" ]; then
     exit
 fi
 
-# change network location
+# change network location: will output "found it!"
 if ! networksetup -switchtolocation "$LOCATION"; then
-    osascript -e 'display notification "Failed to Update Network Location" with title "Network Location Failure"'
+		osascript -e "display notification \"Failed to Change Network Location to: $LOCATION\" with title \"Network Update Failure\""
     exit 1
 fi
+echo "" # add linefeed after output from networksetup
 
 # if present, callout to an external script
-# use this script's dir and convention to determine if there is an external script to be run
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+# use this script's dir and also a file-naming convention to determine if there is an external script to be run
 EXTERNAL_CALLOUT="$SCRIPT_DIR/locationchanger.callout.sh"
 if [[ -x "$EXTERNAL_CALLOUT" ]]; then
+		echo "Calling external executable \"$EXTERNAL_CALLOUT\""
 		output=$($EXTERNAL_CALLOUT)
 		exit_code=$?
-		echo "External callout \"$EXTERNAL_CALLOUT\" returned exit code: $exit_code and output:"
-		echo "$output"
-		echo ""
+		echo "exit code: $exit_code and output: $output"
 fi
 
-case $LOCATION in
-	$Location_Automatic )
-		osascript -e 'display notification "Network Location Changed to Automatic" with title "Network Location Changed"'
-	;;
-
-	$Location_Work )
-		osascript -e 'display notification "Network Location Changed to Work" with title "Network Location Changed"'
-	;;
-
-	$Location_Home )
-		osascript -e 'display notification "Network Location Changed to Home" with title "Network Location Changed"'
-	;;
-	# ... add more here
-esac
+osascript -e "display notification \"Network Location Changed to $LOCATION\" with title \"Network Update\""
 
 echo "--> Location Changer: $LOCATION - $REASON"
 

--- a/locationchanger.conf.sample
+++ b/locationchanger.conf.sample
@@ -1,0 +1,13 @@
+# This is a sample file for creating text file "locationchanger.conf" which associates location names with wifi names.
+# 
+# Below, enter two pieces of text: location and wifi, separated by space(s)
+# If the wifi name contains space(s), make sure to put quotes around that wifi name; location may NOT have any spaces or odd characters.
+# Any line with a pound sign in front will be ignored as a comment. Blank lines are also ignored.
+#
+#
+# LOCATION  WIFI
+#
+# For example:
+# Home myHomeWifiSSID
+# Work "my Work Wifi"
+


### PR DESCRIPTION
* supply sample configuration file with syntax hints
* update README
* configuration file "locationchanger.conf" added to .gitignore since user's configuration is not part of git source
* simplify notification calls by parameterizing message with location name

Left behind are legacy configuration blocks so that there's a path for legacy users to keep their "in source" configuration. Mixed config looks confusing, so "todo" remove those blocks at some point in future.