### PR TITLE
MOD: pass $LOCATION to locationchanger.callout.sh

### DIFF
--- a/locationchanger
+++ b/locationchanger
@@ -98,7 +98,7 @@ echo "" # add linefeed after output from networksetup
 EXTERNAL_CALLOUT="$SCRIPT_DIR/locationchanger.callout.sh"
 if [[ -x "$EXTERNAL_CALLOUT" ]]; then
 		echo "Calling external executable \"$EXTERNAL_CALLOUT\""
-		output=$($EXTERNAL_CALLOUT)
+		output=$($EXTERNAL_CALLOUT "$LOCATION")
 		exit_code=$?
 		echo "exit code: $exit_code and output: $output"
 fi


### PR DESCRIPTION
Pass `$LOCATION` to  ` locationchanger.callout.sh`, so ` locationchanger.callout.sh` can  use this value. 

e.g.
```
WIFI_LOCATION=$1


if [ "$WIFI_LOCATION" = "work" ]; then
   # do something
elif [ "$WIFI_LOCATION" = "home" ]; then
   # do something
else
   # do something
fi

```