### PR TITLE
included instructions in readme.md to fix permission issues for automatic network fallback to Automatic location

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,33 @@ For ease in testing, configure two locations within the current environment, e.g
 ```
 tail /usr/local/var/log/locationchanger.log
 ```
+
+## MacOS Ventura fallback to Automatic location issue
+
+This repository already handles the case already if the SSID is not listed in the config file. In that case it should switch to the location `Automatic`, but it requires root access to do so.
+If you want that it changes the settings without the need to execute it again for each new network with root credentials just add to following to settings and install it again with `./install.sh`:
+
+### Add `<string>/usr/bin/sudo</string>` within the array config
+```xml
+# LocationChanger.plist
+...
+<array>
+    <string>/usr/bin/sudo</string>
+    <string>/usr/local/bin/locationchanger</string>
+</array>
+...
+```
+
+### Modify the sudoers file
+- Run `sudo visudo`
+- replace `your_user_name` with your username
+  - you can type `whoami` to see you current username
+
+```
+# User privilege specification
+root    ALL=(ALL) ALL
+%admin  ALL=(ALL) ALL
+your_user_name ALL=(ALL) NOPASSWD: /usr/local/bin/locationchanger
+```
+
+Run the `./install.sh` script again - and now your location network settings are set to `Automatic` if no mapping has been found!  


### PR DESCRIPTION
It seems that since MacOS Ventura its required to execute the `networksetup -switchtolocation` with root access. Because of this issue the default fallback behavior to the "Automatic" location cannot be executed. Here is the log output:

WIFI1 -> Included in mapping file `locationchanger.conf`
WIFI2 -> Not included in mapping file `locationchanger.conf`

```
tail -f /usr/local/var/log/locationchanger.log
Mon Dec 5 15:32:56 CET 2022 New SSID found: WIFI1
Mon Dec 5 15:51:54 CET 2022 New SSID found: WIFI2
** Error: Command requires admin privileges.
```