### PR TITLE
Update locationchanger - Sonoma patch

### DIFF
--- a/locationchanger
+++ b/locationchanger
@@ -23,7 +23,7 @@ sleep 2
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # get SSID
-SSID=`/System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport -I | awk -F ' SSID: ' '/ SSID:/ {print $2}'`
+SSID=`/usr/bin/wdutil info | awk -F ' SSID.*: ' '/ SSID / {print $2}'`
 echo `date` "New SSID found: $SSID"
 
 # empty location var


### PR DESCRIPTION
Sonoma patch

airport command is not working from Sonoma. Error is below.

WARNING: The airport command line tool is deprecated and will be removed in a future release. For diagnosing Wi-Fi related issues, use the Wireless Diagnostics app or wdutil command line tool.

Changed the airport command to wdutil as described in the error log.