### PR TITLE
Fix macOS version check for SSID detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ sudo visudo
 
 ## macOS Compatibility and Security
 
-### macOS Tahoe 26.0+ Support
-This version includes support for macOS Tahoe 26.0+ by using the Shortcuts app to detect Wi-Fi SSIDs when traditional methods fail. The script automatically falls back to legacy methods if Shortcuts is not available.
+### macOS Sequoia 15.0+ Support
+This version includes support for macOS Sequoia 15.0+ by using the Shortcuts app to detect Wi-Fi SSIDs when traditional methods fail. The script automatically falls back to legacy methods if Shortcuts is not available.
 
-**Note:** macOS 26.0+ has enhanced privacy protections that may prevent automatic SSID detection. If you see `Privacy Protected` or `<redacted>` in the configuration tool, you can still manually configure SSID mappings. For automatic detection, create a Shortcuts app shortcut named "Current Wi-Fi".
+**Note:** macOS 15.0+ has enhanced privacy protections that may prevent automatic SSID detection. If you see `Privacy Protected` or `<redacted>` in the configuration tool, you can still manually configure SSID mappings. For automatic detection, create a Shortcuts app shortcut named "Current Wi-Fi".
 
 ### How To Create "Current Wi-Fi" Shortcut:
 

--- a/locationchanger
+++ b/locationchanger
@@ -15,8 +15,8 @@ get_ssid_comprehensive() {
     local os_version=$(sw_vers -productVersion | cut -d. -f1)
     local ssid=""
     
-    # For macOS 26.0+, try multiple methods due to privacy restrictions
-    if [ "$os_version" -ge "26" ]; then
+    # For macOS 15.0+, try multiple methods due to privacy restrictions
+    if [ "$os_version" -ge "15" ]; then
         echo "$(date) macOS $os_version detected, using comprehensive SSID detection" >&2
         
         # Method 1: Try shortcuts if available
@@ -61,7 +61,7 @@ get_ssid_comprehensive() {
         fi
         echo "$(date) system_profiler method failed or returned redacted" >&2
         
-        echo "$(date) All SSID detection methods failed on macOS 26.0+ - privacy restrictions may be blocking access" >&2
+        echo "$(date) All SSID detection methods failed on macOS 15.0+ - privacy restrictions may be blocking access" >&2
         return 1
     else
         # Legacy method for older macOS versions


### PR DESCRIPTION
- Change version check from 26 to 15 in locationchanger script
- Update README to reflect macOS Sequoia 15.0+ support instead of Tahoe 26.0+
- Fixes issue where SSID detection failed on macOS 15+ due to incorrect version check
- Privacy restrictions affecting SSID detection were introduced in macOS 15, not 26

Resolves SSID detection failures on macOS Sequoia and later versions.